### PR TITLE
Log discovered components on endpoints

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -470,6 +470,13 @@ void Endpoint::_add_sys_comp_id(uint8_t sysid, uint8_t compid)
         log_info("Sniffer sysid %u identified. [%d] is now sniffing all messages",
                  sniffer_sysid,
                  fd);
+    } else {
+        log_info("%s Endpoint [%d]%s: discovered source %u/%u",
+                    _type.c_str(),
+                    fd,
+                    _name.c_str(),
+                    sysid,
+                    compid);
     }
     _sys_comp_ids.push_back(sys_comp_id);
 


### PR DESCRIPTION
Current hypothesis for (at least some of the) parameter monitoring spam is that
mavlink-router sometimes received a corrupt or loopbacked message from PX4
that causes it to not forward any more messages with this ID to PX4.

If the ID matches the ID of parameter monitoring, parameter monitoring is unable to send
new requests for parameter list, and will output that all/most parameters are missing.

This extra logging to mavlink-router is to test this hypothesis before applying a fix.
Should the hypothesis be correct, a simple configuration can be done to fix it.

Note that this error could also potentially block out GCS from sending messages to PX4.
This is replicated in a lab setup, but not confirmed to happen in production.

To confirm hypothesis, when parameter spam happens, mavlink router logs should contains something like
`UART Endpoint [4]px4: discovered source XXX/30`
where XXX is the system id, and 30 is the component id of the parameter monitoring.