### PR TITLE
Add option to exclude LOGGING* messages in telemetry log

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -94,6 +94,12 @@
 # Default: <false>
 # LogTelemetry = false
 
+# Exclude MAVLink messages LOGGING_DATA, LOGGING_DATA_ACKED and LOGGING_ACK
+# from the telemetry log.
+# Valid values: <true>, <false>
+# Default: <false>
+# TelemetryIgnoreLoggingData = false
+
 
 ##
 ## UART Endpoint Configurations

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -47,13 +47,14 @@
 
 // clang-format off
 const ConfFile::OptionsTable LogEndpoint::option_table[] = {
-    {"Log",             false, ConfFile::parse_stdstring,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, logs_dir)},
-    {"LogMode",         false, LogEndpoint::parse_log_mode,         OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_mode)},
-    {"MavlinkDialect",  false, LogEndpoint::parse_mavlink_dialect,  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, mavlink_dialect)},
-    {"MinFreeSpace",    false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, min_free_space)},
-    {"MaxLogFiles",     false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, max_log_files)},
-    {"LogSystemId",     false, LogEndpoint::parse_fcu_id,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, fcu_id)},
-    {"LogTelemetry",    false, ConfFile::parse_bool,                OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_telemetry)},
+    {"Log",                        false, ConfFile::parse_stdstring,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, logs_dir)},
+    {"LogMode",                    false, LogEndpoint::parse_log_mode,         OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_mode)},
+    {"MavlinkDialect",             false, LogEndpoint::parse_mavlink_dialect,  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, mavlink_dialect)},
+    {"MinFreeSpace",               false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, min_free_space)},
+    {"MaxLogFiles",                false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, max_log_files)},
+    {"LogSystemId",                false, LogEndpoint::parse_fcu_id,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, fcu_id)},
+    {"LogTelemetry",               false, ConfFile::parse_bool,                OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_telemetry)},
+    {"TelemetryIgnoreLoggingData", false, ConfFile::parse_bool,                OPTIONS_TABLE_STRUCT_FIELD(LogOptions, telemetry_ignore_logging_data)},
     {}
 };
 // clang-format on

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -46,6 +46,7 @@ struct LogOptions {
     unsigned long max_log_files;                  // conf "MaxLogFiles"
     int fcu_id{-1};                               // conf "LogSystemId"
     bool log_telemetry{false};                    // conf "LogTelemetry"
+    bool telemetry_ignore_logging_data{false};    // conf "TelemetryIgnoreLoggingData"
 };
 
 class LogEndpoint : public Endpoint {

--- a/src/tlog.cpp
+++ b/src/tlog.cpp
@@ -65,6 +65,13 @@ int TLog::write_msg(const struct buffer *buffer)
     /* Check if we should start or stop logging */
     _handle_auto_start_stop(buffer);
 
+    if (_config.telemetry_ignore_logging_data) {
+        // Silently ignore LOGGING_DATA MAVLink messages here, if configured.
+        if (buffer->curr.msg_id == MAVLINK_MSG_ID_LOGGING_DATA) return buffer->len;
+        if (buffer->curr.msg_id == MAVLINK_MSG_ID_LOGGING_DATA_ACKED) return buffer->len;
+        if (buffer->curr.msg_id == MAVLINK_MSG_ID_LOGGING_ACK) return buffer->len;
+    }
+
     uint64_t ms_since_epoch = std::chrono::duration_cast<std::chrono::microseconds>(
                                   std::chrono::system_clock::now().time_since_epoch())
                                   .count();


### PR DESCRIPTION
Preparation for logging telemetry in mavlink-router, and uploading to fms.

---

These message are used to create the ulg/bin flight logs, which are
already active if telemetry logging is used. Excluding these from the
telemetry log greatly reduce the size, with the drawback of not beeing
able to use the sequence number to debug lost messages.
