### PR TITLE
Improve log start/stop control

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -63,7 +63,7 @@
 
 # Define when to store flight stack or telemetry logs. From the start of
 # mavlink-router until it's stopped or just while the vehicle is armed.
-# Valid values: <always>, <while-armed>
+# Valid values: <always>, <while-armed>, <always-reset-disarm>
 # Default: <always>
 #LogMode = always
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -77,6 +77,12 @@
 # Default: 1000
 #LogStartDelayMs = 1000
 
+# Delay in milliseconds from sending a stop log request until closing the file.
+# Only relevant for log types that will send this request.
+# The file may be closed earlier if confirmation is received from the autopilot.
+# Default: 1000
+#LogCloseDelayMs = 1000
+
 # Auto-delete old log files until there's at least the configured amount of
 # bytes free on the storage device. Set to 0 to disable this functionality.
 # Default: 0 (disabled)

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -92,13 +92,18 @@
 # is defined. This also uses LogMode to control the recording.
 # Valid values: <true>, <false>
 # Default: <false>
-# LogTelemetry = false
+#LogTelemetry = false
+
+# Separate LogMode for tlog files.
+# Valid values: <Same as LogMode>
+# Default: <Same as LogMode>
+#TelemetryLogMode = <Same as LogMode>
 
 # Exclude MAVLink messages LOGGING_DATA, LOGGING_DATA_ACKED and LOGGING_ACK
 # from the telemetry log.
 # Valid values: <true>, <false>
 # Default: <false>
-# TelemetryIgnoreLoggingData = false
+#TelemetryIgnoreLoggingData = false
 
 
 ##

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -77,6 +77,11 @@
 # Default: 1000
 #LogStartDelayMs = 1000
 
+# Delay in milliseconds from disarm until stop logging.
+# Only relevant for LogMode "while-armed" and "always-reset-disarm".
+# Default: 0
+#LogStopDelayMs = 0
+
 # Delay in milliseconds from sending a stop log request until closing the file.
 # Only relevant for log types that will send this request.
 # The file may be closed earlier if confirmation is received from the autopilot.

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -72,6 +72,11 @@
 # No default value.
 #LogSystemId = 
 
+# Delay in milliseconds from opening a log file until sending
+# a request to start streaming logs to the autopilot.
+# Default: 1000
+#LogStartDelayMs = 1000
+
 # Auto-delete old log files until there's at least the configured amount of
 # bytes free on the storage device. Set to 0 to disable this functionality.
 # Default: 0 (disabled)

--- a/src/autolog.cpp
+++ b/src/autolog.cpp
@@ -54,11 +54,20 @@ int AutoLog::write_msg(const struct buffer *buffer)
     return buffer->len;
 }
 
-void AutoLog::stop()
+unsigned long AutoLog::_pre_stop()
 {
     if (_logger) {
-        _logger->stop();
+        return _logger->_pre_stop();
     }
+    return 0;
+}
+
+bool AutoLog::_post_stop()
+{
+    if (_logger) {
+        return _logger->_post_stop();
+    }
+    return false;
 }
 
 bool AutoLog::start()

--- a/src/autolog.h
+++ b/src/autolog.h
@@ -33,7 +33,9 @@ public:
     int flush_pending_msgs() override { return -ENOSYS; }
 
     bool start() override;
-    void stop() override;
+    unsigned long _pre_stop() override;
+    bool _post_stop() override;
+
     void print_statistics() override;
 
 protected:

--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -56,16 +56,18 @@ bool BinLog::start()
     return true;
 }
 
-void BinLog::stop()
+unsigned long BinLog::_pre_stop()
 {
     if (_file == -1) {
-        log_info("BinLog not started");
-        return;
+        return 0;
     }
-
     _send_stop();
+    return _config.log_close_delay_ms;
+}
 
-    LogEndpoint::stop();
+bool BinLog::_post_stop()
+{
+    return LogEndpoint::_post_stop();
 }
 
 void BinLog::_send_stop()

--- a/src/binlog.h
+++ b/src/binlog.h
@@ -30,7 +30,8 @@ public:
     }
 
     bool start() override;
-    void stop() override;
+    unsigned long _pre_stop() override;
+    bool _post_stop() override;
 
     bool logging_start_timeout();
 

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -50,6 +50,7 @@ const ConfFile::OptionsTable LogEndpoint::option_table[] = {
     {"Log",                        false, ConfFile::parse_stdstring,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, logs_dir)},
     {"LogMode",                    false, LogEndpoint::parse_log_mode,         OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_mode)},
     {"MavlinkDialect",             false, LogEndpoint::parse_mavlink_dialect,  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, mavlink_dialect)},
+    {"LogStartDelayMs",            false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_start_delay_ms)},
     {"MinFreeSpace",               false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, min_free_space)},
     {"MaxLogFiles",                false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, max_log_files)},
     {"LogSystemId",                false, LogEndpoint::parse_fcu_id,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, fcu_id)},
@@ -389,6 +390,7 @@ void LogEndpoint::stop()
         < (int)sizeof(log_file)) {
         chmod(log_file, S_IRUSR | S_IRGRP | S_IROTH);
     }
+    log_info("Finished logging to %s", _filename);
 }
 
 bool LogEndpoint::start()
@@ -408,7 +410,7 @@ bool LogEndpoint::start()
     }
 
     _timeout.logging_start = Mainloop::get_instance().add_timeout(
-        MSEC_PER_SEC,
+        _config.log_start_delay_ms,
         std::bind(&LogEndpoint::_logging_start_timeout, this),
         this);
     if (!_timeout.logging_start) {

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -205,6 +205,10 @@ void LogEndpoint::_delete_old_logs()
                 // is still being used (not read-only), it should not be deleted.
                 if (!S_ISDIR(file_stat.st_mode) && !(file_stat.st_mode & S_IWUSR)) {
                     std::string str(ent->d_name);
+                    // Use a low index for empty files, and a high one for non-empty.
+                    // This causes empty files to be deleted first, even if
+                    // older non-empty files exists.
+                    if (file_stat.st_size != 0) idx += 0x80000000;
                     file_map[idx] = std::make_tuple(str, file_stat.st_size);
                 }
             }

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -32,6 +32,7 @@
 enum class LogMode {
     always = 0,  ///< Log from start until mavlink-router exits
     while_armed, ///< Start logging when the vehicle is armed until it's disarmed
+    always_reset_disarm,  ///< Log always, but rotate file on disarm
 
     disabled ///< Do not try to start logging (only used internally)
 };
@@ -107,4 +108,5 @@ private:
     void _delete_old_logs();
 
     char _filename[64];
+    bool _last_armed = false;
 };

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -45,6 +45,7 @@ struct LogOptions {
     LogMode log_mode{LogMode::always};                 // conf "LogMode"
     MavDialect mavlink_dialect{MavDialect::Auto};      // conf "MavlinkDialect"
     unsigned long log_start_delay_ms{1000};            // conf "LogStartDelayMs"
+    unsigned long log_stop_delay_ms{0};                // conf "LogStopDelayMs"
     unsigned long log_close_delay_ms{1000};            // conf "LogCloseDelayMs"
     unsigned long min_free_space;                      // conf "MinFreeSpace"
     unsigned long max_log_files;                       // conf "MaxLogFiles"
@@ -83,6 +84,7 @@ protected:
 
     struct {
         Timeout *logging_start = nullptr;
+        Timeout *logging_stop = nullptr;
         Timeout *logging_close = nullptr;
         Timeout *fsync = nullptr;
         Timeout *alive = nullptr;
@@ -100,6 +102,7 @@ protected:
     virtual bool _alive_timeout();
 
     bool _fsync();
+    bool _logging_stop_timeout();
 
     void _handle_auto_start_stop(const struct buffer *pbuf);
 

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -45,6 +45,7 @@ struct LogOptions {
     LogMode log_mode{LogMode::always};                 // conf "LogMode"
     MavDialect mavlink_dialect{MavDialect::Auto};      // conf "MavlinkDialect"
     unsigned long log_start_delay_ms{1000};            // conf "LogStartDelayMs"
+    unsigned long log_close_delay_ms{1000};            // conf "LogCloseDelayMs"
     unsigned long min_free_space;                      // conf "MinFreeSpace"
     unsigned long max_log_files;                       // conf "MaxLogFiles"
     int fcu_id{-1};                                    // conf "LogSystemId"
@@ -58,7 +59,9 @@ public:
     LogEndpoint(std::string name, LogOptions conf);
 
     virtual bool start();
-    virtual void stop();
+    void stop();
+    virtual unsigned long _pre_stop() { return 0; }
+    virtual bool _post_stop();
 
     /**
      * Check existing log files and mark logs as read-only if needed.
@@ -80,6 +83,7 @@ protected:
 
     struct {
         Timeout *logging_start = nullptr;
+        Timeout *logging_close = nullptr;
         Timeout *fsync = nullptr;
         Timeout *alive = nullptr;
     } _timeout;

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -34,20 +34,23 @@ enum class LogMode {
     while_armed, ///< Start logging when the vehicle is armed until it's disarmed
     always_reset_disarm,  ///< Log always, but rotate file on disarm
 
-    disabled ///< Do not try to start logging (only used internally)
+    disabled, ///< Do not try to start logging (only used internally)
+    default_mode  ///< Use the default mode (only used internally)
 };
 
 struct LogOptions {
     enum class MavDialect { Auto, Common, Ardupilotmega };
 
-    std::string logs_dir;                         // conf "Log" or CLI "log"
-    LogMode log_mode{LogMode::always};            // conf "LogMode"
-    MavDialect mavlink_dialect{MavDialect::Auto}; // conf "MavlinkDialect"
-    unsigned long min_free_space;                 // conf "MinFreeSpace"
-    unsigned long max_log_files;                  // conf "MaxLogFiles"
-    int fcu_id{-1};                               // conf "LogSystemId"
-    bool log_telemetry{false};                    // conf "LogTelemetry"
-    bool telemetry_ignore_logging_data{false};    // conf "TelemetryIgnoreLoggingData"
+    std::string logs_dir;                              // conf "Log" or CLI "log"
+    LogMode log_mode{LogMode::always};                 // conf "LogMode"
+    MavDialect mavlink_dialect{MavDialect::Auto};      // conf "MavlinkDialect"
+    unsigned long log_start_delay_ms{1000};            // conf "LogStartDelayMs"
+    unsigned long min_free_space;                      // conf "MinFreeSpace"
+    unsigned long max_log_files;                       // conf "MaxLogFiles"
+    int fcu_id{-1};                                    // conf "LogSystemId"
+    bool log_telemetry{false};                         // conf "LogTelemetry"
+    LogMode telemetry_log_mode{LogMode::default_mode}; // conf "TelemetryLogMode"
+    bool telemetry_ignore_logging_data{false};         // conf "TelemetryIgnoreLoggingData"
 };
 
 class LogEndpoint : public Endpoint {
@@ -95,6 +98,9 @@ protected:
     bool _fsync();
 
     void _handle_auto_start_stop(const struct buffer *pbuf);
+
+    virtual LogMode _get_log_mode() const { return _config.log_mode; }
+    virtual void _set_log_mode(LogMode log_mode) { _config.log_mode = log_mode; }
 
 private:
     int _get_file(const char *extension);

--- a/src/tlog.cpp
+++ b/src/tlog.cpp
@@ -37,21 +37,7 @@ bool TLog::_logging_start_timeout()
 
 bool TLog::start()
 {
-    if (!LogEndpoint::start()) {
-        return false;
-    }
-
-    return true;
-}
-
-void TLog::stop()
-{
-    if (_file == -1) {
-        log_info("TLog not started");
-        return;
-    }
-
-    LogEndpoint::stop();
+    return LogEndpoint::start();
 }
 
 int TLog::write_msg(const struct buffer *buffer)

--- a/src/tlog.cpp
+++ b/src/tlog.cpp
@@ -65,6 +65,11 @@ int TLog::write_msg(const struct buffer *buffer)
     /* Check if we should start or stop logging */
     _handle_auto_start_stop(buffer);
 
+    /* Check if logging is enabled and file is open */
+    if (_file == -1) {
+        return buffer->len;
+    }
+
     if (_config.telemetry_ignore_logging_data) {
         // Silently ignore LOGGING_DATA MAVLink messages here, if configured.
         if (buffer->curr.msg_id == MAVLINK_MSG_ID_LOGGING_DATA) return buffer->len;

--- a/src/tlog.cpp
+++ b/src/tlog.cpp
@@ -82,3 +82,11 @@ int TLog::write_msg(const struct buffer *buffer)
     write(_file, buffer->data, buffer->len);
     return buffer->len;
 }
+
+LogMode TLog::_get_log_mode() const {
+    if (_config.telemetry_log_mode == LogMode::default_mode) {
+        return _config.log_mode;
+    } else {
+        return _config.telemetry_log_mode;
+    }
+}

--- a/src/tlog.h
+++ b/src/tlog.h
@@ -39,4 +39,7 @@ protected:
     bool _logging_start_timeout() override;
 
     const char *_get_logfile_extension() override { return "tlog"; };
+
+    LogMode _get_log_mode() const override;
+    void _set_log_mode(LogMode log_mode) override { _config.telemetry_log_mode = log_mode; }
 };

--- a/src/tlog.h
+++ b/src/tlog.h
@@ -29,7 +29,6 @@ public:
     }
 
     bool start() override;
-    void stop() override;
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }

--- a/src/ulog.h
+++ b/src/ulog.h
@@ -44,6 +44,7 @@ private:
     uint16_t _expected_seq = 0;
     bool _waiting_header = true;
     bool _waiting_first_msg_offset = false;
+    bool _logging_started = false;
 
     uint8_t _buffer[BUFFER_LEN];
     uint16_t _buffer_len = 0;

--- a/src/ulog.h
+++ b/src/ulog.h
@@ -29,7 +29,8 @@ public:
     }
 
     bool start() override;
-    void stop() override;
+    unsigned long _pre_stop() override;
+    bool _post_stop() override;
 
     int write_msg(const struct buffer *buffer) override;
     int flush_pending_msgs() override { return -ENOSYS; }


### PR DESCRIPTION
This PR is mainly on better control of start/stop of mavlink-router logging (ulg and tlog).

- The log mode for tlog can be set independently from ulg.
- New log mode "always-reset-disarm" that always logs, but starts a new file after disarm to finalize logs after each flight.
- Delay between log stop and close file. This makes it possible to capture the end of a log stream, which may contain additional information.
- Add an configurable period to continue logging after disarm, since a few seconds after each flight is often interesting to look at if anything is wrong.


There are also some other fixes/improvements:

- When deleting old files, empty files will be deleted before non-empty. In some error modes, we have seen mavlink-router to create a lot of empty files fast. Since this may cause actual flights to not be uploaded to fms, we need to delete the empty files first.
- Delay until sending "start logging" message is now configurable (was fixed 1 second after opening file). This helps to control that any previous log session have timed out before starting a new one, which again reduce the chance of corrupt logs/massive log restarts. This may not be needed any more, as other fixes in this PR reduce to chance of these problems a lot, but some error modes may still exists, and it is nice to have this parameter ready.
- Do not write to files that are not open. mavlink-router would in many cases attempt to write log data to a "-1" file descriptor. While generally not a problem, it is better to do this correctly. It may also save some processing power to abort log writes earlier in the process (but this is a minor side effect).

**Note: This PR probably breaks "bin" logs (Ardupilot logs?). Not a problem for us, but needs to be handled if it is relevant to share this PR upstream later**