### PR TITLE
tlog: accept all messages

### DIFF
--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -177,7 +177,7 @@ public:
         return has_sys_comp_id(sys_comp_id);
     }
 
-    AcceptState accept_msg(const struct buffer *pbuf) const;
+    virtual AcceptState accept_msg(const struct buffer *pbuf) const;
 
     void filter_add_allowed_out_msg_id(uint32_t msg_id)
     {
@@ -369,7 +369,7 @@ public:
     bool is_valid() override { return _valid; };
     bool is_critical() override { return false; };
 
-    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const;
+    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const override;
 
     int accept(int listener_fd);        ///< accept incoming connection
     bool setup(TcpEndpointConfig conf); ///< open connection and apply config

--- a/src/tlog.h
+++ b/src/tlog.h
@@ -32,6 +32,11 @@ public:
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
+    
+    // Accept everything for tlog
+    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const override {
+        return Endpoint::AcceptState::Accepted;
+    }
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };


### PR DESCRIPTION
Using the default accept_msg for tlog causes a log of messages from GCS
that are not broadcast to be dropped.
